### PR TITLE
Feature/list

### DIFF
--- a/data_utils/df.py
+++ b/data_utils/df.py
@@ -50,6 +50,24 @@ def import_s3_csv_to_df(s3client,
     return df
 
 
+def list_s3_keys_in_bucket(s3client,
+                           bucket,
+                           prefix=''):
+    """
+    Returns a list of the keys situated at the given prefix in the given bucket
+
+    :s3client: boto3.session.Session.client that represents a connection with s3
+    :bucket: string representing the s3 bucket's name
+    :prefix: string representing the base filepath to search at in the s3 bucket, default: ''
+    """
+    keys = []
+    response = s3client.list_objects(Bucket=bucket, Prefix=prefix)['Contents']
+    for __file in response:
+        keys.append(__file['Key'])
+
+    return keys
+
+
 def convert_df_to_s3_compressed_csv(df,
                                     s3client,
                                     bucket,

--- a/data_utils/df.py
+++ b/data_utils/df.py
@@ -10,6 +10,7 @@ import io
 
 import pandas as pd
 import numpy as np
+import tablib
 
 from .utils import (_clear_model_table,
                     _convert_df_to_dataset,
@@ -62,8 +63,8 @@ def list_s3_keys_in_bucket(s3client,
     """
     keys = []
     response = s3client.list_objects(Bucket=bucket, Prefix=prefix)['Contents']
-    for __file in response:
-        keys.append(__file['Key'])
+    for csv in response:
+        keys.append(csv['Key'])
 
     return keys
 
@@ -118,13 +119,17 @@ def convert_df_to_csv(df, filepath, index_label='id', sep=',', encoding='utf-8',
               compression=compression)
 
 
-def convert_df_to_django_model(df, model, rewrite=False):
+def convert_df_to_django_model(df,
+                               model,
+                               rewrite=False,
+                               rows_at_a_time=250):
     """
     Import a given dataframe to Django's ORM with a specified model
 
     :df: pandas.Dataframe to convert
     :model: django.db.models.Model's name. The ORM takes care of which table to put the data in
     :rewrite: boolean representing wether to delete the old entries or not, default: False
+    :rows_at_a_time: int representing the amount of rows to import at the same time, default: 250
     """
     _setup_django()
 
@@ -142,6 +147,9 @@ def convert_df_to_django_model(df, model, rewrite=False):
 
         # Save the data to the database
         p_resource = resources.modelresource_factory(model=model)()
-        p_resource.import_data(dataset)
+        for i in range(0, len(dataset), rows_at_a_time):
+            data = tablib.Dataset(*dataset[i:i+rows_at_a_time],
+                                  headers=dataset.headers)
+            p_resource.import_data(data)
     except Exception as err:
         return print(err)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as desc:
 
 setup(
     name="data_utils",
-    version="0.3.1",
+    version="1.0",
     author="Shawn-Philippe Levasseur",
     author_email="shawnphilippe.levasseur@decathlon.com",
     description="A data manipulation library",


### PR DESCRIPTION
## Bug fix
Due to memory limit on heroku, certain scripts using this library will crash the worker due to exceeding memory allocation while importing a large csv.

Here's the traceback from heroku while importing last_clicked for the mpp-api as shown here #11 :
```
2019-06-07T14:35:01.456219+00:00 heroku[run.8029]: Error R14 (Memory quota exceeded)
2019-06-07T14:35:22.681311+00:00 heroku[run.8029]: Process running mem=1026M(200.5%)
2019-06-07T14:35:22.681311+00:00 heroku[run.8029]: Error R15 (Memory quota vastly exceeded)
2019-06-07T14:35:22.681311+00:00 heroku[run.8029]: Stopping process with SIGKILL
2019-06-07T14:35:25.995317+00:00 heroku[run.8029]: State changed from up to complete
2019-06-07T14:35:25.970401+00:00 heroku[run.8029]: Process exited with status 137
```

Also added a new function that lists the files in a bucket with a prefix if needed